### PR TITLE
Update JNA to 5.11.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>26.0.0</version>
+		<version>31.1.0</version>
 		<relativePath />
 	</parent>
 
@@ -79,7 +79,7 @@
 		<license.licenseName>gpl_v3</license.licenseName>
 		<license.copyrightOwners>Fiji developers.</license.copyrightOwners>
 		<license.projectName>Fiji distribution of ImageJ for the life sciences.</license.projectName>
-
+		<jna.version>5.11.0</jna.version>
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>sign,deploy-to-scijava</releaseProfiles>
 	</properties>

--- a/src/main/java/CPU_Meter.java
+++ b/src/main/java/CPU_Meter.java
@@ -15,7 +15,7 @@ import java.awt.event.WindowEvent;
 public class CPU_Meter implements PlugIn {
 	public interface CLibrary extends Library {
 		CLibrary INSTANCE = (CLibrary)
-			Native.loadLibrary(Platform.isWindows() ? "msvcrt" : "c", CLibrary.class);
+			Native.load(Platform.isWindows() ? "msvcrt" : "c", CLibrary.class);
 
 		int getloadavg(double[] loadavg, int nelem);
 	}


### PR DESCRIPTION
Update JNA to 5.11.0
Change Native.load to Native.loadLibrary due to deprecation.
Update scijava-pom to 31.1.0

This update is meant to indicate compatibility with new scijava-pom and JNA 5.

xref: https://github.com/scijava/pom-scijava/issues/163

